### PR TITLE
fix: add repo as base for gh pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "/whatgoeswhere/",
 });


### PR DESCRIPTION
Base is required when deploying gh pages with repo in url